### PR TITLE
I've updated the version of `karma-coverage-istanbul-reporter` from `…

### DIFF
--- a/Chapter01/FirstProject/package.json
+++ b/Chapter01/FirstProject/package.json
@@ -37,7 +37,7 @@
     "karma": "~6.4.4",
     "karma-chrome-launcher": "~2.1.1",
     "karma-cli": "~1.0.1",
-    "karma-coverage-istanbul-reporter": "^1.2.1",
+    "karma-coverage-istanbul-reporter": "^3.0.3",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
     "protractor": "~7.0.0",

--- a/Chapter04/PropertiesAndEvents/package.json
+++ b/Chapter04/PropertiesAndEvents/package.json
@@ -37,7 +37,7 @@
     "karma": "~6.4.4",
     "karma-chrome-launcher": "~2.1.1",
     "karma-cli": "~1.0.1",
-    "karma-coverage-istanbul-reporter": "^1.2.1",
+    "karma-coverage-istanbul-reporter": "^3.0.3",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
     "protractor": "~7.0.0",

--- a/Chapter05/PipeDemos/package.json
+++ b/Chapter05/PipeDemos/package.json
@@ -38,7 +38,7 @@
     "karma": "~6.4.4",
     "karma-chrome-launcher": "~2.1.1",
     "karma-cli": "~1.0.1",
-    "karma-coverage-istanbul-reporter": "^1.2.1",
+    "karma-coverage-istanbul-reporter": "^3.0.3",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
     "protractor": "~7.0.0",

--- a/Chapter06/ModuleExample/package.json
+++ b/Chapter06/ModuleExample/package.json
@@ -38,7 +38,7 @@
     "karma": "~6.4.4",
     "karma-chrome-launcher": "~2.1.1",
     "karma-cli": "~1.0.1",
-    "karma-coverage-istanbul-reporter": "^1.2.1",
+    "karma-coverage-istanbul-reporter": "^3.0.3",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
     "protractor": "~7.0.0",

--- a/Chapter07/Chapter7/package.json
+++ b/Chapter07/Chapter7/package.json
@@ -38,7 +38,7 @@
     "karma": "~6.4.4",
     "karma-chrome-launcher": "~2.1.1",
     "karma-cli": "~1.0.1",
-    "karma-coverage-istanbul-reporter": "^1.2.1",
+    "karma-coverage-istanbul-reporter": "^3.0.3",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
     "protractor": "~7.0.0",

--- a/Chapter08/FirebaseDemo/package.json
+++ b/Chapter08/FirebaseDemo/package.json
@@ -40,7 +40,7 @@
     "karma": "~6.4.4",
     "karma-chrome-launcher": "~2.1.1",
     "karma-cli": "~1.0.1",
-    "karma-coverage-istanbul-reporter": "^1.2.1",
+    "karma-coverage-istanbul-reporter": "^3.0.3",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
     "protractor": "~7.0.0",

--- a/Chapter09/RouterDemo/package.json
+++ b/Chapter09/RouterDemo/package.json
@@ -38,7 +38,7 @@
     "karma": "~6.4.4",
     "karma-chrome-launcher": "~2.1.1",
     "karma-cli": "~1.0.1",
-    "karma-coverage-istanbul-reporter": "^1.2.1",
+    "karma-coverage-istanbul-reporter": "^3.0.3",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
     "protractor": "~7.0.0",

--- a/Chapter10/ReactiveForms/package.json
+++ b/Chapter10/ReactiveForms/package.json
@@ -38,7 +38,7 @@
     "karma": "~6.4.4",
     "karma-chrome-launcher": "~2.1.1",
     "karma-cli": "~1.0.1",
-    "karma-coverage-istanbul-reporter": "^1.2.1",
+    "karma-coverage-istanbul-reporter": "^3.0.3",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
     "protractor": "~7.0.0",

--- a/Chapter11/MaterialDemo/package.json
+++ b/Chapter11/MaterialDemo/package.json
@@ -40,7 +40,7 @@
     "karma": "~6.4.4",
     "karma-chrome-launcher": "~2.1.1",
     "karma-cli": "~1.0.1",
-    "karma-coverage-istanbul-reporter": "^1.2.1",
+    "karma-coverage-istanbul-reporter": "^3.0.3",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
     "protractor": "~7.0.0",

--- a/Chapter12/AnimationsDemo/package.json
+++ b/Chapter12/AnimationsDemo/package.json
@@ -38,7 +38,7 @@
     "karma": "~6.4.4",
     "karma-chrome-launcher": "~2.1.1",
     "karma-cli": "~1.0.1",
-    "karma-coverage-istanbul-reporter": "^1.2.1",
+    "karma-coverage-istanbul-reporter": "^3.0.3",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
     "protractor": "~7.0.0",

--- a/Chapter13/AngularTestingDemo/package.json
+++ b/Chapter13/AngularTestingDemo/package.json
@@ -38,7 +38,7 @@
     "karma": "~6.4.4",
     "karma-chrome-launcher": "~2.1.1",
     "karma-cli": "~1.0.1",
-    "karma-coverage-istanbul-reporter": "^1.2.1",
+    "karma-coverage-istanbul-reporter": "^3.0.3",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
     "protractor": "~7.0.0",


### PR DESCRIPTION
…^1.2.1` to `^3.0.3` in all package.json files across your projects.

Unfortunately, I couldn't verify the update by running tests because of some existing configuration issues in your project. It looks like your Angular CLI setup is a bit outdated and isn't compatible with the newer @angular/cli versions. To get the tests running smoothly, your projects will need to be migrated to a newer Angular workspace structure (angular.json).

I did take a look at your karma.conf.js files, and their configurations for coverageIstanbulReporter seem standard and should work well with the new reporter version.